### PR TITLE
feat: prepare package for PyPI distribution as momentum-task

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ storage.json
 test_storage.json
 .vscode/
 .coverage
+dist/

--- a/README.md
+++ b/README.md
@@ -29,9 +29,19 @@ Momentum/
 
 You need Python 3.8 or newer.
 
-Install in editable/development mode:
+### Install from PyPI (Recommended)
 
 ```sh
+pip install momentum-task
+```
+
+### Install from Source
+
+For development or to get the latest changes:
+
+```sh
+git clone https://github.com/DanielWJudge/Momentum.git
+cd momentum
 pip install -e .
 ```
 
@@ -177,7 +187,7 @@ pytest
 
 ```bash
 # Clone and enter
-git clone https://github.com/yourusername/Momentum.git
+git clone https://github.com/DanielWJudge/Momentum.git
 cd Momentum
 
 # Optional: Virtual environment (recommended)
@@ -337,7 +347,7 @@ Momentum welcomes contributions! The codebase is clean, tested, and documented.
 
 ```bash
 # Set up development environment
-git clone https://github.com/yourusername/Momentum.git
+git clone https://github.com/DanielWJudge/Momentum.git
 cd Momentum
 python -m venv .venv
 source .venv/bin/activate
@@ -444,7 +454,7 @@ Found a bug? Have an idea? PRs and issues welcome!
 
 If Momentum helps you ship faster, **star this repo** to help others discover it!
 
-**[⭐ Star on GitHub](https://github.com/yourusername/Momentum)**
+**[⭐ Star on GitHub](https://github.com/DanielWJudge/Momentum)**
 
 ## ⏱️ Pomodoro Timer
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,24 +3,45 @@ requires = ["hatchling"]
 build-backend = "hatchling.build"
 
 [project]
-name = "momentum"
+name = "momentum-task"
 version = "0.1.0"
-description = "A minimal, one-task-at-a-time CLI tracker."
+description = "A minimal, one-task-at-a-time CLI tracker with built-in Pomodoro timer"
 authors = [
     { name = "Daniel Judge", email = "dwjref+momentum@gmail.com" }
 ]
 readme = "README.md"
 requires-python = ">=3.8"
 license = { file = "LICENSE" }
+keywords = ["productivity", "task-management", "cli", "pomodoro", "todo", "gtd"]
 classifiers = [
-    "Programming Language :: Python :: 3",
+    "Development Status :: 4 - Beta",
+    "Environment :: Console",
+    "Intended Audience :: Developers",
+    "Intended Audience :: End Users/Desktop",
     "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.8",
+    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Topic :: Office/Business :: Scheduling",
+    "Topic :: Utilities",
 ]
 dependencies = []
+
+[project.urls]
+"Homepage" = "https://github.com/DanielWJudge/Momentum"
+"Bug Reports" = "https://github.com/DanielWJudge/Momentum/issues"
+"Source" = "https://github.com/DanielWJudge/Momentum"
+"Documentation" = "https://github.com/DanielWJudge/Momentum#readme"
 
 [project.scripts]
 momentum = "momentum.__main__:main"
 
 [tool.hatch.build.targets.wheel]
-packages = ["src/momentum"] 
+packages = ["src/momentum"]
+
+[tool.hatch.version]
+path = "src/momentum/__init__.py"

--- a/src/momentum/__init__.py
+++ b/src/momentum/__init__.py
@@ -1,3 +1,9 @@
-"""Momentum - A minimal, one-task-at-a-time CLI tracker."""
+"""Momentum - A minimal, one-task-at-a-time CLI tracker.
+
+Stop juggling endless task lists. Start shipping.
+"""
 
 __version__ = "0.1.0"
+__author__ = "Daniel Judge"
+__email__ = "dwjref+momentum@gmail.com"
+__all__ = ["__version__"]


### PR DESCRIPTION
BREAKING CHANGE: Package will be distributed as 'momentum-task' on PyPI due to naming conflict with existing 'momentum' package.

- Rename package from 'momentum' to 'momentum-task' in pyproject.toml
- Add comprehensive PyPI metadata (keywords, classifiers, project URLs)
- Update package metadata in __init__.py with version and author info
- Configure hatchling to use __init__.py as version source
- Update README installation instructions for PyPI distribution
- Maintain 'momentum' as the import name and CLI command for compatibility

Users will install via 'pip install momentum-task' but still import as 'momentum' and use 'momentum' command. This follows common Python packaging patterns (e.g., discord.py → discord, beautifulsoup4 → bs4).

Part of #35: Set up PyPI Publishing Pipeline